### PR TITLE
Dramatically improved filter performance on large datasets

### DIFF
--- a/ashaw_notes/gui/main.py
+++ b/ashaw_notes/gui/main.py
@@ -92,10 +92,10 @@ class App(QMainWindow):
         connector = self.connection_manager.get_primary_connector()
         notes = connector.find_notes(terms)
         self.logger.debug("[Filter] Found %s notes", len(notes))
+        html = ''
         for timestamp, note in notes:
-            self.notes_txt.insertHtml(
-                "%s<br>" %
-                self.plugin_manager.format_note_line(timestamp, note))
+            html += "%s<br>" % self.plugin_manager.format_note_line(timestamp, note)
+        self.notes_txt.insertHtml(html)
         self.logger.debug("[Filter] Notes Filtered")
         self.notes_txt.verticalScrollBar().setValue(
             self.notes_txt.verticalScrollBar().maximum()


### PR DESCRIPTION
Dramatically improved filter performance on large datasets by reducing draw calls.
For large datasets (over 100 notes) excessive calls on QTextBrowser::insertHtml were destroying the performance of the application.

Example: On a large dataset filter which returned 872 matches, the application would freeze for 4.75 seconds while all the notes were drawn to the display.

By constructing the resultant DOM and making a single draw call to the element, this time was dropped down to 210ms.